### PR TITLE
Correct an error in unzipping the model file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To download the model from command line:
 ```
 # command line
 gdown 1ejNOMXdycorDzphLT6jnfGIPUxi6fO0g # pip install gdown
-unzip dnabert-s_train.zip  # unzip the data 
+unzip DNABERT-S.zip  # unzip the model
 ```
 
 


### PR DESCRIPTION
Hi, I found that the name of files containing downloaded model is incorrect, and I have fixed the problem in readme file:

<img width="765" alt="image" src="https://github.com/user-attachments/assets/0f810fd4-9302-4d54-be80-3d4432bc8343">


It should be all in the upper form. Thanks a lot.